### PR TITLE
Handlers only execute appropriate commands.

### DIFF
--- a/Play.cpp
+++ b/Play.cpp
@@ -179,7 +179,17 @@ InputHandler::Handler getPlayHandler()
 	{
 		Command* command = Command::read(input);
 		if (command != nullptr)
-			return command->doCommandFunc();
+		{
+			CommandInfo cmdInfo = command->getCommandInfo();
+
+			if (cmdInfo.isType(CommandType::FINISH))
+				return command->doCommandFunc();
+
+			else if (cmdInfo.isType(CommandType::BOOST) && Play::getStage() == PlayStage::ANSWER)
+				return command->doCommandFunc();
+
+			return InputHandler::Returns::INVALID_STATE;
+		}
 
 		if (Play::getStage() == PlayStage::QUESTION)
 		{

--- a/Write.cpp
+++ b/Write.cpp
@@ -14,9 +14,16 @@ InputHandler::Handler Write::getWriteHandler()
 {
 	static InputHandler::Handler writeHandler = [](std::wstring input) -> InputHandler::Returns
 	{
-		Command* cmd = Command::read(input);
-		if (cmd != nullptr)
-			return cmd->doCommandFunc();
+		Command* command = Command::read(input);
+		if (command != nullptr)
+		{
+			CommandInfo cmdInfo = command->getCommandInfo();
+
+			if (cmdInfo.isType(CommandType::CANCEL))
+				return command->doCommandFunc();
+
+			return InputHandler::Returns::INVALID_STATE;
+		}
 
 		if (_stage == Stage::INPUT)
 		{


### PR DESCRIPTION
Handlers only execute commands if they are used in an appropriate context. You can't cancel writing a question unless you're writing a question; you can't boost unless you've just got a question wrong in play; etc.