### PR TITLE
Issue 10

### DIFF
--- a/Flashcard.cpp
+++ b/Flashcard.cpp
@@ -29,6 +29,14 @@ bool Flashcard::isCorrect(std::wstring guess)
 	return _caseSensitive ? (guess == _answer) : (toUpper(guess) == toUpper(_answer));
 }
 
+void Flashcard::writeChildData(std::wofstream& stream)
+{
+	if (_caseSensitive)
+		Option(_optCaseSensitive).write(stream);
+	stream << _question << L"\n";
+	stream << _answer << L"\n";
+}
+
 bool Flashcard::isCaseSensitive()
 {
 	return _caseSensitive;

--- a/Flashcard.cpp
+++ b/Flashcard.cpp
@@ -51,19 +51,3 @@ void Flashcard::setCaseInsensitive()
 {
 	_caseSensitive = false;
 }
-
-Question* Flashcard::readFlashcard(std::wifstream& stream)
-{
-	std::vector<Option> options = Option::readOptions(stream);
-	bool caseSensitive = std::find_if(options.begin(), options.end(), [](Option opt) -> bool {return opt.getOption() == _optCaseSensitive; }) != options.end();
-
-	if (stream.eof())
-		return nullptr;
-	std::wstring question = getInputLine(stream);
-
-	if (stream.eof())
-		return nullptr;
-	std::wstring answer = getInputLine(stream);
-
-	return new Flashcard(question, answer, caseSensitive);
-}

--- a/Flashcard.cpp
+++ b/Flashcard.cpp
@@ -51,3 +51,19 @@ void Flashcard::setCaseInsensitive()
 {
 	_caseSensitive = false;
 }
+
+Question* Flashcard::readFlashcard(std::wifstream& stream)
+{
+	std::vector<Option> options = Option::readOptions(stream);
+	bool caseSensitive = std::find_if(options.begin(), options.end(), [](Option opt) -> bool {return opt.getOption() == _optCaseSensitive; }) != options.end();
+
+	if (stream.eof())
+		return nullptr;
+	std::wstring question = getInputLine(stream);
+
+	if (stream.eof())
+		return nullptr;
+	std::wstring answer = getInputLine(stream);
+
+	return new Flashcard(question, answer, caseSensitive);
+}

--- a/Flashcard.cpp
+++ b/Flashcard.cpp
@@ -29,14 +29,6 @@ bool Flashcard::isCorrect(std::wstring guess)
 	return _caseSensitive ? (guess == _answer) : (toUpper(guess) == toUpper(_answer));
 }
 
-void Flashcard::writeChildData(std::wofstream& stream)
-{
-	if (_caseSensitive)
-		Option(_optCaseSensitive).write(stream);
-	stream << _question << L"\n";
-	stream << _answer << L"\n";
-}
-
 bool Flashcard::isCaseSensitive()
 {
 	return _caseSensitive;

--- a/Flashcard.h
+++ b/Flashcard.h
@@ -11,7 +11,6 @@ private:
 	std::wstring _answer;
 	bool _caseSensitive;
 	static const std::wstring _optCaseSensitive;
-	void writeChildData(std::wofstream& stream);
 public:
 	Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, std::vector<std::wstring> tags = std::vector<std::wstring>());
 	std::wstring getQuestion();

--- a/Flashcard.h
+++ b/Flashcard.h
@@ -11,6 +11,7 @@ private:
 	std::wstring _answer;
 	bool _caseSensitive;
 	static const std::wstring _optCaseSensitive;
+	void writeChildData(std::wofstream& stream);
 public:
 	Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, std::vector<std::wstring> tags = std::vector<std::wstring>());
 	std::wstring getQuestion();

--- a/Flashcard.h
+++ b/Flashcard.h
@@ -20,4 +20,5 @@ public:
 	bool isCaseSensitive();
 	void setCaseSensitive();
 	void setCaseInsensitive();
+	static Question* readFlashcard(std::wifstream& stream);
 };

--- a/Flashcard.h
+++ b/Flashcard.h
@@ -20,5 +20,4 @@ public:
 	bool isCaseSensitive();
 	void setCaseSensitive();
 	void setCaseInsensitive();
-	static Question* readFlashcard(std::wifstream& stream);
 };

--- a/FlashcardReader.cpp
+++ b/FlashcardReader.cpp
@@ -4,6 +4,7 @@
 #include "Option.h"
 #include "QuestionType.h"
 #include "globals.h"
+#include "util.h"
 
 namespace FlashcardReader
 {
@@ -25,13 +26,13 @@ namespace FlashcardReader
 		// if we get any extra inputs after front and back are filled, they are ignored
 	}
 
-	Question* construct(std::vector<Option> options, std::vector<std::wstring> tags)
+	Question* construct(easy_list::list<Option> options, std::vector<std::wstring> tags)
 	{
 		if (front == L"")
 			return nullptr;
 		if (back == L"")
 			return nullptr;
-		bool caseSensitive = options.end() != std::find_if(options.begin(), options.end(), [](Option opt) -> bool { return opt.getOption() == Globals::optionCaseSensitive; });
+		bool caseSensitive = (options.count(toUpper(Globals::optionCaseSensitive), &Option::getOption) >= 1);
 		return new Flashcard(front, back, caseSensitive, tags);
 	}
 

--- a/QuestionReader.cpp
+++ b/QuestionReader.cpp
@@ -1,3 +1,4 @@
+#include<easy_list.h>
 #include "QuestionReader.h"
 #include "Option.h"
 #include "util.h"
@@ -6,7 +7,7 @@
 QuestionReader::QuestionReader(
 	void(*clearChildData)(),
 	void(*readChildData)(std::wstring line),
-	Question*(*constructCurrent)(std::vector<Option> options, std::vector<std::wstring> tags))
+	Question*(*constructCurrent)(easy_list::list<Option> options, std::vector<std::wstring> tags))
 	:
 	_clearChildData(clearChildData),
 	_readChildData(readChildData),
@@ -19,7 +20,7 @@ Question* QuestionReader::read(std::wifstream& stream)
 	std::vector<std::wstring> tags = std::vector<std::wstring>();
 	_clearChildData();
 
-	std::vector<Option> options = Option::readOptions(stream);
+	easy_list::list<Option> options = Option::readOptions(stream);
 
 	while (!stream.eof())
 	{

--- a/QuestionReader.h
+++ b/QuestionReader.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <fstream>
+#include <easy_list.h>
 #include "Question.h"
 #include "QuestionType.h"
 #include "QuestionList.h"
@@ -11,7 +12,7 @@ public:
 	QuestionReader(
 		void(*clearChildData)(),
 		void(*readChildData)(std::wstring line),
-		Question*(*constructCurrent)(std::vector<Option> options, std::vector<std::wstring> tags));
+		Question*(*constructCurrent)(easy_list::list<Option> options, std::vector<std::wstring> tags));
 	Question* read(std::wifstream& stream);
 private:
 	enum class Stage {
@@ -20,5 +21,5 @@ private:
 	};
 	void (*_clearChildData)();
 	void (*_readChildData)(std::wstring line);
-	Question* (*_constructCurrent)(std::vector<Option> options, std::vector<std::wstring> tags);
+	Question* (*_constructCurrent)(easy_list::list<Option> options, std::vector<std::wstring> tags);
 };

--- a/globals.cpp
+++ b/globals.cpp
@@ -1,7 +1,7 @@
 #include "globals.h"
 
 const std::wstring Globals::fileEscapeChar = L"%%";
-const std::wstring Globals::fileStartOfTags = Globals::fileEscapeChar + L"tags";
-const std::wstring Globals::optionCaseSensitive = L"case_sensitive";
+const std::wstring Globals::fileStartOfTags = Globals::fileEscapeChar + L"TAGS";
+const std::wstring Globals::optionCaseSensitive = L"CASE_SENSITIVE";
 const std::wstring Globals::horizontalRule = L"--------------------------------";
 const std::wstring Globals::horizontalDoubleRule = L"================================";


### PR DESCRIPTION
Fixes #10 . Ironically, it was a case-sensitivity issue: options are always initialised upper-case, whereas the global value storing the option code was formerly lower-case (now set to upper-case, just in case). So,"CASE_SENSITIVE" was being checked for equality against "case_sensitive". There are now belt and braces: the global value is upper-case, and the flashcard reader converts it to upper-case anyway.