### PR TITLE
Easylists everywhere

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -45,17 +45,15 @@ Command* Command::read(std::wifstream& stream)
 Command* Command::read(std::wstring userInput)
 {
 	easy_list::list<std::wstring> words = splitByWord(toUpper(userInput));
-	if (words.size() == 0)
+	if (words.size() == 0 || words[0].size() == 0 || words[0][0] != L'\\')
 		return nullptr;
 	std::wstring code = words[0].substr(1);
 
 	auto cmdInfoIter = CommandInfo::get(code);
-	if (cmdInfoIter == CommandInfo::getList()->end())
+	if (cmdInfoIter == CommandInfo::getList()->npos())
 		return nullptr;
 
-	return new Command(
-		easy_list::list<std::wstring>(words.begin() + 1, words.end(), std::allocator<std::wstring>()),
-		*cmdInfoIter);
+	return new Command(words.slice(1), *cmdInfoIter);
 }
 
 InputHandler::Returns Command::doCommandFunc()

--- a/Command.cpp
+++ b/Command.cpp
@@ -44,7 +44,7 @@ Command* Command::read(std::wifstream& stream)
 
 Command* Command::read(std::wstring userInput)
 {
-	std::vector<std::wstring> words = splitByWord(toUpper(userInput));
+	easy_list::list<std::wstring> words = splitByWord(toUpper(userInput));
 	if (words.size() == 0)
 		return nullptr;
 	std::wstring code = words[0].substr(1);
@@ -54,7 +54,7 @@ Command* Command::read(std::wstring userInput)
 		return nullptr;
 
 	return new Command(
-		std::vector<std::wstring>(words.begin() + 1, words.end(), std::allocator<std::wstring>()),
+		easy_list::list<std::wstring>(words.begin() + 1, words.end(), std::allocator<std::wstring>()),
 		*cmdInfoIter);
 }
 
@@ -68,12 +68,12 @@ CommandInfo Command::getCommandInfo()
 	return _commandInfo;
 }
 
-const std::vector<std::wstring> Command::getArgs() const
+const easy_list::list<std::wstring> Command::getArgs() const
 {
 	return _args;
 }
 
-Command::Command(std::vector<std::wstring> args, CommandInfo commandInfo) :
+Command::Command(easy_list::list<std::wstring> args, CommandInfo commandInfo) :
 	_args(args),
 	_commandInfo(commandInfo)
 {}

--- a/Command.cpp
+++ b/Command.cpp
@@ -9,13 +9,13 @@
 const easy_list::list<CommandInfo>* CommandInfo::getList()
 {
 	static const auto list = easy_list::list<CommandInfo>({
-		CommandInfo(CommandType::QUIT, L"QUIT", &cmdFuncQuit),
-		CommandInfo(CommandType::EXIT, L"EXIT", &cmdFuncQuit),
-		CommandInfo(CommandType::WRITE, L"WRITE", &Write::cmdFuncWrite),
-		CommandInfo(CommandType::CANCEL, L"CANCEL", &Write::cmdFuncCancel),
-		CommandInfo(CommandType::BOOST, L"BOOST", &Play::cmdFuncBoost),
-		CommandInfo(CommandType::CONCEDE, L"CONCEDE", &Play::cmdFuncConcede),
-		CommandInfo(CommandType::PLAY, L"PLAY", &Play::cmdFuncPlay)
+		CommandInfo(CommandType::QUIT, L"quit", &cmdFuncQuit),
+		CommandInfo(CommandType::EXIT, L"exit", &cmdFuncQuit),
+		CommandInfo(CommandType::WRITE, L"write", &Write::cmdFuncWrite),
+		CommandInfo(CommandType::CANCEL, L"cancel", &Write::cmdFuncCancel),
+		CommandInfo(CommandType::BOOST, L"boost", &Play::cmdFuncBoost),
+		CommandInfo(CommandType::CONCEDE, L"concede", &Play::cmdFuncConcede),
+		CommandInfo(CommandType::PLAY, L"play", &Play::cmdFuncPlay)
 	});
 	return &list;
 }
@@ -44,7 +44,7 @@ Command* Command::read(std::wifstream& stream)
 
 Command* Command::read(std::wstring userInput)
 {
-	easy_list::list<std::wstring> words = splitByWord(toUpper(userInput));
+	easy_list::list<std::wstring> words = splitByWord(toLower(userInput));
 	if (words.size() == 0 || words[0].size() == 0 || words[0][0] != L'\\')
 		return nullptr;
 	std::wstring code = words[0].substr(1);

--- a/Command.h
+++ b/Command.h
@@ -1,12 +1,11 @@
 #pragma once
 #include <string>
-#include <vector>
-#include <fstream>
 #include <easy_list.h>
+#include <fstream>
 #include "InputHandler.h"
 
 #define DEFINE_CMD_FUNC(func) const CommandFunc func
-#define DECLARE_CMD_FUNC(func) const CommandFunc func = [](std::vector<std::wstring> args = std::vector<std::wstring>()) -> InputHandler::Returns
+#define DECLARE_CMD_FUNC(func) const CommandFunc func = [](easy_list::list<std::wstring> args = easy_list::list<std::wstring>()) -> InputHandler::Returns
 
 enum class CommandType {
 	CANCEL,
@@ -18,14 +17,14 @@ enum class CommandType {
 	PLAY
 };
 
-typedef InputHandler::Returns (*CommandFunc) (std::vector<std::wstring> args);
+typedef InputHandler::Returns (*CommandFunc) (easy_list::list<std::wstring> args);
 
 class CommandInfo {
 public:
 	const CommandType getType() const { return _type; }
 	const std::wstring getCode() const { return _code; }
 	const CommandFunc* getFunc() const { return _func; }
-	const InputHandler::Returns callFunc(std::vector<std::wstring> args) { return (*_func)(args); }
+	const InputHandler::Returns callFunc(easy_list::list<std::wstring> args) { return (*_func)(args); }
 	static const easy_list::list<CommandInfo>* getList();
 	static const easy_list::list<CommandInfo>::const_iterator get(const CommandType type);
 	static const easy_list::list<CommandInfo>::const_iterator get(const std::wstring code);
@@ -52,9 +51,9 @@ public:
 	static Command* read(std::wstring userInput);
 	InputHandler::Returns doCommandFunc();
 	CommandInfo getCommandInfo();
-	const std::vector<std::wstring> getArgs() const;
+	const easy_list::list<std::wstring> getArgs() const;
 private:
 	CommandInfo _commandInfo;
-	std::vector<std::wstring> _args;
-	Command(std::vector<std::wstring> args, CommandInfo commandInfo);
+	easy_list::list<std::wstring> _args;
+	Command(easy_list::list<std::wstring> args, CommandInfo commandInfo);
 };

--- a/Flashcard.cpp
+++ b/Flashcard.cpp
@@ -4,8 +4,6 @@
 #include "util.h"
 #include "Option.h"
 
-const std::wstring Flashcard::_optCaseSensitive = L"case_sensitive";
-
 Flashcard::Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, easy_list::list<std::wstring> tags) :
 	Question(QuestionType::FLASHCARD, tags),
 	_question(question),
@@ -26,13 +24,13 @@ std::wstring Flashcard::getAnswer()
 
 bool Flashcard::isCorrect(std::wstring guess)
 {
-	return _caseSensitive ? (guess == _answer) : (toUpper(guess) == toUpper(_answer));
+	return _caseSensitive ? (guess == _answer) : (toLower(guess) == toLower(_answer));
 }
 
 void Flashcard::writeChildData(std::wofstream& stream)
 {
 	if (_caseSensitive)
-		Option(_optCaseSensitive).write(stream);
+		Option(Globals::optionCaseSensitive).write(stream);
 	stream << _question << L"\n";
 	stream << _answer << L"\n";
 }

--- a/Flashcard.cpp
+++ b/Flashcard.cpp
@@ -55,7 +55,7 @@ void Flashcard::setCaseInsensitive()
 Question* Flashcard::readFlashcard(std::wifstream& stream)
 {
 	easy_list::list<Option> options = Option::readOptions(stream);
-	bool caseSensitive = std::find_if(options.begin(), options.end(), [](Option opt) -> bool {return opt.getOption() == _optCaseSensitive; }) != options.end();
+	bool caseSensitive = options.contains(Globals::optionCaseSensitive, &Option::getOption);
 
 	if (stream.eof())
 		return nullptr;

--- a/Flashcard.cpp
+++ b/Flashcard.cpp
@@ -6,7 +6,7 @@
 
 const std::wstring Flashcard::_optCaseSensitive = L"case_sensitive";
 
-Flashcard::Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, std::vector<std::wstring> tags) :
+Flashcard::Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, easy_list::list<std::wstring> tags) :
 	Question(QuestionType::FLASHCARD, tags),
 	_question(question),
 	_answer(answer),
@@ -54,7 +54,7 @@ void Flashcard::setCaseInsensitive()
 
 Question* Flashcard::readFlashcard(std::wifstream& stream)
 {
-	std::vector<Option> options = Option::readOptions(stream);
+	easy_list::list<Option> options = Option::readOptions(stream);
 	bool caseSensitive = std::find_if(options.begin(), options.end(), [](Option opt) -> bool {return opt.getOption() == _optCaseSensitive; }) != options.end();
 
 	if (stream.eof())

--- a/Flashcard.h
+++ b/Flashcard.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <string>
-#include <vector>
+#include <easy_list.h>
 #include <fstream>
 #include "Question.h"
 
@@ -13,7 +13,7 @@ private:
 	static const std::wstring _optCaseSensitive;
 	void writeChildData(std::wofstream& stream);
 public:
-	Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, std::vector<std::wstring> tags = std::vector<std::wstring>());
+	Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, easy_list::list<std::wstring> tags = easy_list::list<std::wstring>());
 	std::wstring getQuestion();
 	std::wstring getAnswer();
 	bool isCorrect(std::wstring guess);

--- a/Flashcard.h
+++ b/Flashcard.h
@@ -10,7 +10,6 @@ private:
 	std::wstring _question;
 	std::wstring _answer;
 	bool _caseSensitive;
-	static const std::wstring _optCaseSensitive;
 	void writeChildData(std::wofstream& stream);
 public:
 	Flashcard(std::wstring question, std::wstring answer, bool caseSensitive, easy_list::list<std::wstring> tags = easy_list::list<std::wstring>());

--- a/FlashcardReader.cpp
+++ b/FlashcardReader.cpp
@@ -32,7 +32,7 @@ namespace FlashcardReader
 			return nullptr;
 		if (back == L"")
 			return nullptr;
-		bool caseSensitive = options.contains(toUpper(Globals::optionCaseSensitive), &Option::getOption);
+		bool caseSensitive = options.contains(toLower(Globals::optionCaseSensitive), &Option::getOption);
 		return new Flashcard(front, back, caseSensitive, tags);
 	}
 

--- a/FlashcardReader.cpp
+++ b/FlashcardReader.cpp
@@ -26,7 +26,7 @@ namespace FlashcardReader
 		// if we get any extra inputs after front and back are filled, they are ignored
 	}
 
-	Question* construct(easy_list::list<Option> options, std::vector<std::wstring> tags)
+	Question* construct(easy_list::list<Option> options, easy_list::list<std::wstring> tags)
 	{
 		if (front == L"")
 			return nullptr;

--- a/FlashcardReader.cpp
+++ b/FlashcardReader.cpp
@@ -32,7 +32,7 @@ namespace FlashcardReader
 			return nullptr;
 		if (back == L"")
 			return nullptr;
-		bool caseSensitive = (options.count(toUpper(Globals::optionCaseSensitive), &Option::getOption) >= 1);
+		bool caseSensitive = options.contains(toUpper(Globals::optionCaseSensitive), &Option::getOption);
 		return new Flashcard(front, back, caseSensitive, tags);
 	}
 

--- a/FlashcardWriter.cpp
+++ b/FlashcardWriter.cpp
@@ -1,6 +1,6 @@
 #include <iostream>
 #include <string>
-#include <vector>
+#include <easy_list.h>
 #include <Windows.h>
 #include <exception>
 #include <fstream>
@@ -116,7 +116,7 @@ namespace FlashcardWriter
 		return false;
 	}
 
-	Question* constructCurrent(std::vector<std::wstring> tags)
+	Question* constructCurrent(easy_list::list<std::wstring> tags)
 	{
 		if (front == L"")
 			return nullptr;

--- a/Option.cpp
+++ b/Option.cpp
@@ -23,7 +23,7 @@ easy_list::list<Option> Option::readOptions(std::wifstream& stream)
 
 Option* Option::readOption(std::wstring userInput)
 {
-	easy_list::list<std::wstring> words = splitByWord(toUpper(userInput));
+	easy_list::list<std::wstring> words = splitByWord(toLower(userInput));
 	if (words.size() == 0)
 		return nullptr;
 

--- a/Option.cpp
+++ b/Option.cpp
@@ -1,5 +1,4 @@
 #include <string>
-#include <vector>
 #include <easy_list.h>
 #include "Option.h"
 #include "util.h"
@@ -24,7 +23,7 @@ easy_list::list<Option> Option::readOptions(std::wifstream& stream)
 
 Option* Option::readOption(std::wstring userInput)
 {
-	std::vector<std::wstring> words = splitByWord(toUpper(userInput));
+	easy_list::list<std::wstring> words = splitByWord(toUpper(userInput));
 	if (words.size() == 0)
 		return nullptr;
 
@@ -34,10 +33,10 @@ Option* Option::readOption(std::wstring userInput)
 
 	return new Option(
 		words[0].substr(Globals::fileEscapeChar.size()),
-		std::vector<std::wstring>(words.begin() + 1, words.end()));
+		easy_list::list<std::wstring>(words.begin() + 1, words.end()));
 }
 
-void Option::constructor(std::wstring option, std::vector<std::wstring> args)
+void Option::constructor(std::wstring option, easy_list::list<std::wstring> args)
 {
 	_option = option;
 	_args = args;
@@ -45,15 +44,15 @@ void Option::constructor(std::wstring option, std::vector<std::wstring> args)
 
 Option::Option(std::wstring option)
 {
-	constructor(option, std::vector<std::wstring>());
+	constructor(option, easy_list::list<std::wstring>());
 }
 
 Option::Option(std::wstring option, std::wstring arg)
 {
-	constructor(option, std::vector<std::wstring>(1, arg));
+	constructor(option, easy_list::list<std::wstring>(1, arg));
 }
 
-Option::Option(std::wstring option, std::vector<std::wstring> args)
+Option::Option(std::wstring option, easy_list::list<std::wstring> args)
 {
 	constructor(option, args);
 }
@@ -70,7 +69,7 @@ std::wstring Option::getArgument(unsigned int n) const
 	return _args[n];
 }
 
-std::vector<std::wstring> Option::getArguments() const
+easy_list::list<std::wstring> Option::getArguments() const
 {
 	return _args;
 }

--- a/Option.cpp
+++ b/Option.cpp
@@ -33,7 +33,7 @@ Option* Option::readOption(std::wstring userInput)
 
 	return new Option(
 		words[0].substr(Globals::fileEscapeChar.size()),
-		easy_list::list<std::wstring>(words.begin() + 1, words.end()));
+		words.slice(1));
 }
 
 void Option::constructor(std::wstring option, easy_list::list<std::wstring> args)
@@ -49,7 +49,7 @@ Option::Option(std::wstring option)
 
 Option::Option(std::wstring option, std::wstring arg)
 {
-	constructor(option, easy_list::list<std::wstring>(1, arg));
+	constructor(option, easy_list::list<std::wstring>({ arg }));
 }
 
 Option::Option(std::wstring option, easy_list::list<std::wstring> args)
@@ -77,7 +77,7 @@ easy_list::list<std::wstring> Option::getArguments() const
 void Option::write(std::wofstream& stream)
 {
 	stream << Globals::fileEscapeChar << _option;
-	for (unsigned int i = 0; i < _args.size(); i++)
-		stream << L" " << _args[i];
+	for (auto arg : _args)
+		stream << L" " << arg;
 	stream << L"\n";
 }

--- a/Option.h
+++ b/Option.h
@@ -1,22 +1,21 @@
 #pragma once
 #include <string>
-#include <vector>
-#include <fstream>
 #include <easy_list.h>
+#include <fstream>
 
 class Option
 {
 protected:
 	std::wstring _option;
-	std::vector<std::wstring> _args;
-	void constructor(std::wstring option, std::vector<std::wstring> args);
+	easy_list::list<std::wstring> _args;
+	void constructor(std::wstring option, easy_list::list<std::wstring> args);
 public:
 	Option(std::wstring option);
 	Option(std::wstring option, std::wstring arg);
-	Option(std::wstring option, std::vector<std::wstring> args);;
+	Option(std::wstring option, easy_list::list<std::wstring> args);;
 	std::wstring getOption() const;
 	std::wstring getArgument(unsigned int n) const;
-	std::vector<std::wstring> getArguments() const;
+	easy_list::list<std::wstring> getArguments() const;
 	static easy_list::list<Option> readOptions(std::wifstream& stream);
 	static Option* readOption(std::wstring userInput);
 	void write(std::wofstream& stream);

--- a/Play.cpp
+++ b/Play.cpp
@@ -64,7 +64,6 @@ DECLARE_CMD_FUNC(Play::cmdFuncPlay)
 	}
 
 	std::wcout << L"Starting play with ";
-	_questions = easy_list::list<Question*>();
 	if (args.empty())
 	{
 		std::wcout << L"all ";

--- a/Play.cpp
+++ b/Play.cpp
@@ -1,6 +1,4 @@
 #include <iostream>
-#include <algorithm>
-#include <time.h>
 #include <random>
 #include <easy_list.h>
 #include "Play.h"
@@ -60,7 +58,10 @@ DECLARE_CMD_FUNC(Play::cmdFuncPlay)
 	if (args.empty())
 		_questions = QuestionList::get();
 	else
-		_questions = QuestionList::get().select([](Question* q) -> bool { q->getTags().contains(})
+	{
+		auto questionHasAnyTag = [args](Question* q) -> bool { return q->getTags().shares(args); };
+		_questions = QuestionList::get().select(questionHasAnyTag);
+	}
 
 	std::wcout << L"Starting play with ";
 	_questions = easy_list::list<Question*>();
@@ -69,15 +70,15 @@ DECLARE_CMD_FUNC(Play::cmdFuncPlay)
 		std::wcout << L"all ";
 	}
 	std::wcout << _questions.size()
-		<< (_questions.size() > 1 ? L" cards" : L" card") << L"...\n\n"
+		<< (_questions.size() == 1 ? L" card" : L" cards") << L"...\n\n"
 		<< Globals::horizontalDoubleRule << L"\n\n"
 		<< L"You'll get given questions, and you'll have to answer correctly. "
 		<< L"If you think you've been marked down unfairly, type the command <"
 		<< toLower(CommandInfo::get(CommandType::BOOST)->getCode())
-		<< L"> before the next card rolls on. Good luck!\n\n"
+		<< L"> before the next question rolls in. Good luck!\n\n"
 		<< Globals::horizontalRule << L"\n\n";
 
-	std::shuffle(_questions.begin(), _questions.end(), std::default_random_engine((unsigned int)time(NULL)));
+	_questions.shuffle();
 	_index = 0;
 	_correct = 0;
 	_wrong = 0;

--- a/Play.cpp
+++ b/Play.cpp
@@ -2,6 +2,7 @@
 #include <algorithm>
 #include <time.h>
 #include <random>
+#include <easy_list.h>
 #include "Play.h"
 #include "InputHandler.h"
 #include "Question.h"
@@ -56,23 +57,16 @@ bool Play::updateAnswer(std::wstring answer)
 
 DECLARE_CMD_FUNC(Play::cmdFuncPlay)
 {
+	if (args.empty())
+		_questions = QuestionList::get();
+	else
+		_questions = QuestionList::get().select([](Question* q) -> bool { q->getTags().contains(})
+
 	std::wcout << L"Starting play with ";
-	_questions = std::vector<Question*>();
+	_questions = easy_list::list<Question*>();
 	if (args.empty())
 	{
-		_questions = QuestionList::get();
 		std::wcout << L"all ";
-	}
-	else
-	{
-		std::vector<Question*> questionList = QuestionList::get();
-		for (unsigned int i = 0; i < questionList.size(); i++)
-		{
-			std::vector<std::wstring> thisQuestionTags = questionList[i]->getTags();
-			std::transform(thisQuestionTags.begin(), thisQuestionTags.end(), thisQuestionTags.begin(), toUpper);
-			if (shareAnyElems<std::wstring>(args, thisQuestionTags))
-				_questions.push_back(questionList[i]);
-		}
 	}
 	std::wcout << _questions.size()
 		<< (_questions.size() > 1 ? L" cards" : L" card") << L"...\n\n"
@@ -164,7 +158,7 @@ std::wstring Play::getCurrentCorrectAnswer()
 }
 
 PlayStage Play::_stage = PlayStage::QUESTION;
-std::vector<Question*> Play::_questions = std::vector<Question*>();
+easy_list::list<Question*> Play::_questions = easy_list::list<Question*>();
 unsigned int Play::_index = 0;
 int Play::_correct = 0;
 int Play::_wrong = 0;

--- a/Play.h
+++ b/Play.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <vector>
+#include <easy_list.h>
 #include <string>
 #include "Flashcard.h"
 #include "Command.h"
@@ -25,7 +25,7 @@ public:
 	static std::wstring getCurrentCorrectAnswer();
 private:
 	static PlayStage _stage;
-	static std::vector<Question*> _questions;
+	static easy_list::list<Question*> _questions;
 	static unsigned int _index;
 	static int _correct;
 	static int _wrong;

--- a/Question.cpp
+++ b/Question.cpp
@@ -4,9 +4,9 @@
 #include "globals.h"
 #include "QuestionTypeInfo.h"
 
-std::vector<std::wstring> Question::readTags(std::wifstream& stream)
+easy_list::list<std::wstring> Question::readTags(std::wifstream& stream)
 {
-	std::vector<std::wstring> tags = std::vector<std::wstring>();
+	easy_list::list<std::wstring> tags = easy_list::list<std::wstring>();
 	while (!stream.eof())
 	{
 		std::wstring line = getInputLine(stream);
@@ -19,7 +19,7 @@ std::vector<std::wstring> Question::readTags(std::wifstream& stream)
 	return tags;
 }
 
-Question::Question(QuestionType type, std::vector<std::wstring> tags) :
+Question::Question(QuestionType type, easy_list::list<std::wstring> tags) :
 	_type(type),
 	_tags(tags)
 {}
@@ -33,7 +33,7 @@ void Question::write(std::wofstream& stream)
 	stream << L"\n";
 }
 
-std::vector<std::wstring> Question::getTags()
+easy_list::list<std::wstring> Question::getTags()
 {
 	return _tags;
 }

--- a/Question.cpp
+++ b/Question.cpp
@@ -28,8 +28,8 @@ void Question::write(std::wofstream& stream)
 {
 	writeChildData(stream);
 	stream << Globals::fileEscapeChar << L"tags\n";
-	for (unsigned int i = 0; i < _tags.size(); i++)
-		stream << _tags[i] << L"\n";
+	for (auto tag : _tags)
+		stream << tag << L"\n";
 	stream << L"\n";
 }
 

--- a/Question.h
+++ b/Question.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <vector>
+#include <easy_list.h>
 #include <string>
 #include <fstream>
 #include <map>
@@ -8,18 +8,18 @@
 class Question
 {
 private:
-	static std::vector<Question*> _questionList;
+	static easy_list::list<Question*> _questionList;
 protected:
 	QuestionType _type;
-	std::vector<std::wstring> _tags;
-	static std::vector<std::wstring> readTags(std::wifstream& stream);
+	easy_list::list<std::wstring> _tags;
+	static easy_list::list<std::wstring> readTags(std::wifstream& stream);
 	virtual void writeChildData(std::wofstream& stream) = 0;
 public:
-	Question(QuestionType type, std::vector<std::wstring> tags = std::vector<std::wstring>());
+	Question(QuestionType type, easy_list::list<std::wstring> tags = easy_list::list<std::wstring>());
 	virtual std::wstring getQuestion() = 0;
 	virtual std::wstring getAnswer() = 0;
 	virtual bool isCorrect(std::wstring guess) = 0;
 	void write(std::wofstream& stream);
-	std::vector<std::wstring> getTags();
+	easy_list::list<std::wstring> getTags();
 	QuestionType getType();
 };

--- a/QuestionList.cpp
+++ b/QuestionList.cpp
@@ -19,7 +19,7 @@ void QuestionList::append(Question* question)
 
 void QuestionList::append(easy_list::list<Question*> questions)
 {
-	questionList.insert(questionList.end(), questions.begin(), questions.end());
+	questionList += questions;
 }
 
 void QuestionList::clear()

--- a/QuestionList.cpp
+++ b/QuestionList.cpp
@@ -1,4 +1,3 @@
-#include <vector>
 #include <easy_list.h>
 #include "QuestionList.h"
 #include "Question.h"
@@ -18,12 +17,12 @@ void QuestionList::append(Question* question)
 	questionList.push_back(question);
 }
 
-void QuestionList::append(std::vector<Question*> questions)
+void QuestionList::append(easy_list::list<Question*> questions)
 {
 	questionList.insert(questionList.end(), questions.begin(), questions.end());
 }
 
 void QuestionList::clear()
 {
-	questionList = std::vector<Question*>();
+	questionList = easy_list::list<Question*>();
 }

--- a/QuestionList.h
+++ b/QuestionList.h
@@ -1,5 +1,4 @@
 #pragma once
-#include <vector>
 #include <easy_list.h>
 #include "Question.h"
 
@@ -7,6 +6,6 @@ namespace QuestionList
 {
 	const easy_list::list<Question*> get();
 	void append(Question* question);
-	void append(std::vector<Question*> questions);
+	void append(easy_list::list<Question*> questions);
 	void clear();
 }

--- a/QuestionReader.cpp
+++ b/QuestionReader.cpp
@@ -1,4 +1,4 @@
-#include<easy_list.h>
+#include <easy_list.h>
 #include "QuestionReader.h"
 #include "Option.h"
 #include "util.h"
@@ -7,7 +7,7 @@
 QuestionReader::QuestionReader(
 	void(*clearChildData)(),
 	void(*readChildData)(std::wstring line),
-	Question*(*constructCurrent)(easy_list::list<Option> options, std::vector<std::wstring> tags))
+	Question*(*constructCurrent)(easy_list::list<Option> options, easy_list::list<std::wstring> tags))
 	:
 	_clearChildData(clearChildData),
 	_readChildData(readChildData),
@@ -17,7 +17,7 @@ QuestionReader::QuestionReader(
 Question* QuestionReader::read(std::wifstream& stream)
 {
 	Stage stage = Stage::CHILD_DATA;
-	std::vector<std::wstring> tags = std::vector<std::wstring>();
+	easy_list::list<std::wstring> tags = easy_list::list<std::wstring>();
 	_clearChildData();
 
 	easy_list::list<Option> options = Option::readOptions(stream);

--- a/QuestionReader.h
+++ b/QuestionReader.h
@@ -12,7 +12,7 @@ public:
 	QuestionReader(
 		void(*clearChildData)(),
 		void(*readChildData)(std::wstring line),
-		Question*(*constructCurrent)(easy_list::list<Option> options, std::vector<std::wstring> tags));
+		Question*(*constructCurrent)(easy_list::list<Option> options, easy_list::list<std::wstring> tags));
 	Question* read(std::wifstream& stream);
 private:
 	enum class Stage {
@@ -21,5 +21,5 @@ private:
 	};
 	void (*_clearChildData)();
 	void (*_readChildData)(std::wstring line);
-	Question* (*_constructCurrent)(easy_list::list<Option> options, std::vector<std::wstring> tags);
+	Question* (*_constructCurrent)(easy_list::list<Option> options, easy_list::list<std::wstring> tags);
 };

--- a/QuestionTypeInfo.cpp
+++ b/QuestionTypeInfo.cpp
@@ -26,7 +26,8 @@ const easy_list::list<QuestionTypeInfo>::const_iterator QuestionTypeInfo::get(st
 
 const std::string QuestionTypeInfo::getFileAddress() const
 {
-	std::wstring typeName = toLower(_displaySingular);
-	std::replace(typeName.begin(), typeName.end(), L' ', L'_');
-	return "userdata_" + std::string(typeName.begin(), typeName.end()) + ".txt";
+	std::string typeName = std::string(_displaySingular.begin(), _displaySingular.end());
+	easy_list::list<char> fileAddress = easy_list::list<char>(typeName.begin(), typeName.end());
+	fileAddress = fileAddress.replace('_', ' ');
+	return "userdata_" + std::string(fileAddress.begin(), fileAddress.end());
 }

--- a/QuestionTypeInfo.cpp
+++ b/QuestionTypeInfo.cpp
@@ -9,7 +9,7 @@
 const easy_list::list<QuestionTypeInfo>* QuestionTypeInfo::getList()
 {
 	static const auto list = easy_list::list<QuestionTypeInfo>({
-		QuestionTypeInfo(QuestionType::FLASHCARD, L"flashcard", L"FLASHCARD", FlashcardWriter::get(), FlashcardReader::get())
+		QuestionTypeInfo(QuestionType::FLASHCARD, L"flashcard", L"flashcard", FlashcardWriter::get(), FlashcardReader::get())
 	});
 	return &list;
 }

--- a/QuestionTypeInfo.cpp
+++ b/QuestionTypeInfo.cpp
@@ -29,5 +29,5 @@ const std::string QuestionTypeInfo::getFileAddress() const
 	std::string typeName = std::string(_displaySingular.begin(), _displaySingular.end());
 	easy_list::list<char> fileAddress = easy_list::list<char>(typeName.begin(), typeName.end());
 	fileAddress = fileAddress.replace('_', ' ');
-	return "userdata_" + std::string(fileAddress.begin(), fileAddress.end());
+	return "userdata_" + std::string(fileAddress.begin(), fileAddress.end()) + ".txt";
 }

--- a/QuestionTypeInfo.cpp
+++ b/QuestionTypeInfo.cpp
@@ -1,6 +1,5 @@
-#include <vector>
-#include <algorithm>
 #include <easy_list.h>
+#include <algorithm>
 #include "QuestionTypeInfo.h"
 #include "FlashcardWriter.h"
 #include "FlashcardReader.h"

--- a/QuestionWriter.cpp
+++ b/QuestionWriter.cpp
@@ -10,7 +10,7 @@
 #include "util.h"
 
 QuestionWriter::Stage QuestionWriter::_stage = QuestionWriter::Stage::CHILD_DATA;
-std::vector<std::wstring> QuestionWriter::_tags = std::vector<std::wstring>();
+easy_list::list<std::wstring> QuestionWriter::_tags = easy_list::list<std::wstring>();
 
 QuestionWriter::QuestionWriter(
 	QuestionType type,
@@ -18,7 +18,7 @@ QuestionWriter::QuestionWriter(
 	void(*startInputData)(),
 	bool(*inputData)(std::wstring userInput),
 	void(*resetLastChildDataStep)(),
-	Question*(*constructCurrent)(std::vector<std::wstring> tags))
+	Question*(*constructCurrent)(easy_list::list<std::wstring> tags))
 	:
 	_type(type),
 	_startWritingMessage(startWritingMessage),
@@ -36,7 +36,7 @@ const std::wstring QuestionWriter::getStartWritingMessage() const
 void QuestionWriter::startInput()
 {
 	_stage = Stage::CHILD_DATA;
-	_tags = std::vector<std::wstring>();
+	_tags = easy_list::list<std::wstring>();
 	_startInputData();
 }
 
@@ -94,7 +94,7 @@ void QuestionWriter::processInput(std::wstring userInput)
 	}
 }
 
-std::vector<Question*> QuestionWriter::writeToFile()
+easy_list::list<Question*> QuestionWriter::writeToFile()
 {
 	std::wofstream file;
 	try
@@ -107,7 +107,7 @@ std::vector<Question*> QuestionWriter::writeToFile()
 	{
 		std::wcout << L"Oops! Something went wrong when trying to access the destination file. We got the following error message:\n"
 			<< e.what() << L"\n";
-		return std::vector<Question*>();
+		return easy_list::list<Question*>();
 	}
 
 	int numWritten;
@@ -116,7 +116,7 @@ std::vector<Question*> QuestionWriter::writeToFile()
 
 	file.close();
 
-	return std::vector<Question*>(_newQuestions.begin(), _newQuestions.begin() + numWritten, std::allocator<Question*>());
+	return easy_list::list<Question*>(_newQuestions.begin(), _newQuestions.begin() + numWritten, std::allocator<Question*>());
 }
 
 void QuestionWriter::setStage(Stage stage)

--- a/QuestionWriter.cpp
+++ b/QuestionWriter.cpp
@@ -110,13 +110,12 @@ easy_list::list<Question*> QuestionWriter::writeToFile()
 		return easy_list::list<Question*>();
 	}
 
-	int numWritten;
-	for (numWritten = 0; numWritten < _newQuestions.size(); numWritten++)
-		_newQuestions[numWritten]->write(file);
+	for (Question* question : _newQuestions)
+		question->write(file);
 
 	file.close();
 
-	return easy_list::list<Question*>(_newQuestions.begin(), _newQuestions.begin() + numWritten, std::allocator<Question*>());
+	return _newQuestions;
 }
 
 void QuestionWriter::setStage(Stage stage)

--- a/QuestionWriter.h
+++ b/QuestionWriter.h
@@ -12,13 +12,13 @@ public:
 		void (*startInputData)(),
 		bool (*inputData)(std::wstring userInput),
 		void (*resetLastChildDataStep)(),
-		Question* (*constructCurrent)(std::vector<std::wstring> tags)
+		Question* (*constructCurrent)(easy_list::list<std::wstring> tags)
 	);
 	const std::wstring getStartWritingMessage() const;
 	void startInput();
 	void resetLastStep();
 	void processInput(std::wstring userInput);
-	std::vector<Question*> writeToFile();
+	easy_list::list<Question*> writeToFile();
 
 private:
 	enum class Stage {
@@ -27,16 +27,16 @@ private:
 	};
 
 	static Stage _stage;
-	static std::vector<std::wstring> _tags;
+	static easy_list::list<std::wstring> _tags;
 
 	QuestionType _type;
 	std::wstring _startWritingMessage;
-	std::vector<Question*> _newQuestions;
+	easy_list::list<Question*> _newQuestions;
 
 	void (*_startInputData)();
 	bool (*_inputData)(std::wstring userInput);
 	void (*_resetLastChildDataStep)();
-	Question* (*_constructCurrent)(std::vector<std::wstring> tags);
+	Question* (*_constructCurrent)(easy_list::list<std::wstring> tags);
 
 	void setStage(Stage stage);
 };

--- a/Write.cpp
+++ b/Write.cpp
@@ -49,7 +49,7 @@ DECLARE_CMD_FUNC(Write::cmdFuncWrite) {
 		return InputHandler::Returns::TOO_FEW_ARGS;
 
 	auto questionTypeInfo = QuestionTypeInfo::get(args[0]);
-	if (questionTypeInfo == QuestionTypeInfo::getList()->end())
+	if (questionTypeInfo == QuestionTypeInfo::getList()->npos())
 		return InputHandler::Returns::INVALID_ARGS;
 
 	InputHandler::set(getWriteHandler());

--- a/globals.cpp
+++ b/globals.cpp
@@ -1,7 +1,7 @@
 #include "globals.h"
 
 const std::wstring Globals::fileEscapeChar = L"%%";
-const std::wstring Globals::fileStartOfTags = Globals::fileEscapeChar + L"TAGS";
-const std::wstring Globals::optionCaseSensitive = L"CASE_SENSITIVE";
+const std::wstring Globals::fileStartOfTags = Globals::fileEscapeChar + L"tags";
+const std::wstring Globals::optionCaseSensitive = L"case_sensitive";
 const std::wstring Globals::horizontalRule = L"--------------------------------";
 const std::wstring Globals::horizontalDoubleRule = L"================================";

--- a/main.cpp
+++ b/main.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include <vector>
+#include <easy_list.h>
 #include "InputHandler.h"
 #include "util.h"
 #include "globals.h"

--- a/util.cpp
+++ b/util.cpp
@@ -97,9 +97,9 @@ const YesNo getYesNo(std::wstring str)
 	return YesNo::OTHER;
 }
 
-std::vector<std::wstring> splitByWord(std::wstring wstr)
+easy_list::list<std::wstring> splitByWord(std::wstring wstr)
 {
-	std::vector<std::wstring> result = std::vector<std::wstring>();
+	easy_list::list<std::wstring> result = easy_list::list<std::wstring>();
 
 	std::wstring currentStr = L"";
 	for (unsigned int i = 0; i < wstr.length(); i++)

--- a/util.cpp
+++ b/util.cpp
@@ -53,15 +53,6 @@ bool inputYesNo(std::wstring message, bool doPrintResult)
 	}
 }
 
-std::wstring toUpper(std::wstring wstr)
-{
-	std::wstring result = L"";
-	for (unsigned int i = 0; i < wstr.length(); i++) {
-		result.push_back(std::toupper(wstr[i]));
-	}
-	return result;
-}
-
 std::wstring toLower(std::wstring wstr)
 {
 	std::wstring result = L"";
@@ -87,10 +78,10 @@ std::wstring indent(std::wstring wstr, int numTabs)
 
 const YesNo getYesNo(std::wstring str)
 {
-	str = toUpper(str);
-	if (str == L"Y" || str == L"YES" || str == L"1" || str == L"T" || str == L"TRUE")
+	str = toLower(str);
+	if (str == L"y" || str == L"yes" || str == L"1" || str == L"T" || str == L"true")
 		return YesNo::YES;
-	if (str == L"N" || str == L"NO" || str == L"0" || str == L"F" || str == L"FALSE")
+	if (str == L"n" || str == L"no" || str == L"0" || str == L"F" || str == L"false")
 		return YesNo::NO;
 	if (Command::read(str) != nullptr)
 		return YesNo::COMMAND;

--- a/util.h
+++ b/util.h
@@ -24,7 +24,6 @@ private:
 };
 std::wstring getInputLine(std::wistream &stream = std::wcin);
 bool inputYesNo(std::wstring message, bool doPrintResult = true);
-std::wstring toUpper(std::wstring wstr);
 std::wstring toLower(std::wstring wstr);
 std::wstring indent(std::wstring wstr, int numTabs);
 const YesNo getYesNo(std::wstring wstr);

--- a/util.h
+++ b/util.h
@@ -29,39 +29,3 @@ std::wstring toLower(std::wstring wstr);
 std::wstring indent(std::wstring wstr, int numTabs);
 const YesNo getYesNo(std::wstring wstr);
 easy_list::list<std::wstring> splitByWord(std::wstring wstr);
-
-template <typename T1, typename T2> easy_list::list<T2> convv(easy_list::list<T1> v)
-{
-	easy_list::list<T2> result = easy_list::list<T2>();
-	result.reserve(v.size());
-	for (int i = 0; i < v.size(); i++)
-		result.push_back((T2)v[i]);
-	return result;
-}
-
-template <typename T> easy_list::list<T> slice(easy_list::list<T> v, int start = 0, int end = -1)
-{
-	easy_list::list<T> result = easy_list::list<T>();
-
-	if (end < 0)
-		end = v.size();
-
-	for (int i = start; i < end; i++)
-		result.push_back(v[i]);
-
-	return result;
-}
-
-template <typename T> bool shareAnyElems(easy_list::list<T> v1, easy_list::list<T> v2)
-{
-
-	for (unsigned int i = 0; i < v1.size(); i++)
-	{
-		for (unsigned int j = 0; j < v2.size(); j++)
-		{
-			if (v1[i] == v2[j])
-				return true;
-		}
-	}
-	return false;
-}

--- a/util.h
+++ b/util.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <string>
 #include <iostream>
-#include <vector>
+#include <easy_list.h>
 
 class YesNo {
 public:
@@ -28,20 +28,20 @@ std::wstring toUpper(std::wstring wstr);
 std::wstring toLower(std::wstring wstr);
 std::wstring indent(std::wstring wstr, int numTabs);
 const YesNo getYesNo(std::wstring wstr);
-std::vector<std::wstring> splitByWord(std::wstring wstr);
+easy_list::list<std::wstring> splitByWord(std::wstring wstr);
 
-template <typename T1, typename T2> std::vector<T2> convv(std::vector<T1> v)
+template <typename T1, typename T2> easy_list::list<T2> convv(easy_list::list<T1> v)
 {
-	std::vector<T2> result = std::vector<T2>();
+	easy_list::list<T2> result = easy_list::list<T2>();
 	result.reserve(v.size());
 	for (int i = 0; i < v.size(); i++)
 		result.push_back((T2)v[i]);
 	return result;
 }
 
-template <typename T> std::vector<T> slice(std::vector<T> v, int start = 0, int end = -1)
+template <typename T> easy_list::list<T> slice(easy_list::list<T> v, int start = 0, int end = -1)
 {
-	std::vector<T> result = std::vector<T>();
+	easy_list::list<T> result = easy_list::list<T>();
 
 	if (end < 0)
 		end = v.size();
@@ -52,7 +52,7 @@ template <typename T> std::vector<T> slice(std::vector<T> v, int start = 0, int 
 	return result;
 }
 
-template <typename T> bool shareAnyElems(std::vector<T> v1, std::vector<T> v2)
+template <typename T> bool shareAnyElems(easy_list::list<T> v1, easy_list::list<T> v2)
 {
 
 	for (unsigned int i = 0; i < v1.size(); i++)


### PR DESCRIPTION
Uses easy_list::list everywhere in preference to std::vector. Also switches from preferring upper-case to preferring lower-case.