### PR TITLE
Fixes "all 1 card..." display glitch

### DIFF
--- a/Play.cpp
+++ b/Play.cpp
@@ -82,7 +82,7 @@ DEFINE_CMD_FUNC(Play::cmdFuncPlay)
 	}
 
 	std::wcout << L"Starting play with ";
-	if (args.empty())
+	if (args.empty() && _questions.size() > 1)
 	{
 		std::wcout << L"all ";
 	}


### PR DESCRIPTION
The user is no longer told "Starting play with all 1 card..." - instead, they're simply told "Starting play with 1 card..."