### PR TITLE
Fixes multiple codes for one command

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -45,7 +45,7 @@ easy_list::list<Command> Command::makePossibleCommands(std::wstring input)
 		return {};
 	std::wstring code = words[0].substr(1);
 
-	auto possibleCommandInfos = CommandInfo::getList()->select(code, &CommandInfo::getCode);
+	auto possibleCommandInfos = CommandInfo::getList()->select(true, &CommandInfo::hasCode, code);
 
 	auto args = words.slice(1);
 	return possibleCommandInfos.transform<Command>(

--- a/Command.h
+++ b/Command.h
@@ -24,6 +24,7 @@ class CommandInfo {
 public:
 	const CommandType getType() const { return _type; }
 	const std::wstring getCode() const { return _codes[0]; }
+	const bool hasCode(const std::wstring code) const { return _codes.contains(code); }
 	const CommandFunc getFunc() const { return _func; }
 	CommandHandlerReturns callFunc(easy_list::list<std::wstring> args) const { return _func(args); }
 	static const easy_list::list<CommandInfo>* getList();
@@ -36,7 +37,6 @@ private:
 	const CommandType _type;
 	const easy_list::list<std::wstring> _codes;
 	const CommandFunc _func;
-	bool hasCode(const std::wstring& code) const { return _codes.contains(code); }
 	CommandInfo(const CommandType type, easy_list::list<std::wstring> codes, const CommandFunc func) :
 		_type(type),
 		_codes(codes),


### PR DESCRIPTION
Multiple codes for a single command now works - previously, the provided input would only be checked against the first code for the command. Now, the whole list of codes for the command gets searched.