### PR TITLE
Command flags

### DIFF
--- a/Command.cpp
+++ b/Command.cpp
@@ -59,15 +59,33 @@ easy_list::list<Command> Command::makePossibleCommands(std::wstring input)
 	auto args = easy_list::list<std::wstring>();
 	auto flags = CommandFlags::NONE;
 
-	for each (auto word in words.slice(1))
+	// Get all args
+	for (int i = 1; i < words.size(); i++)
 	{
-		if (!word.empty() && word[0] == L'-')
+		std::wstring word = words[i];
+
+		if (word.empty())
+			continue;
+
+		// Store arg, unless it's a flag!
+		if (word[0] != L'-')
 		{
-			CommandFlags flag = readCommandFlag(word.substr(1));
-			flags &= flag;
-		}
-		else
 			args.push_back(word);
+		}
+
+		// Flags must always come together at the end. So if we've got
+		// a flag, retrieve flags until we run out flags, then finish.
+		else
+		{
+			for (; i < words.size(); i++)
+			{
+				word = words[i];
+				if (word[0] != L'-')
+					break;
+				flags &= readCommandFlag(word.substr(1));
+			}
+			break;
+		}
 	}
 
 	return possibleCommandInfos.transform<Command>(

--- a/Command.h
+++ b/Command.h
@@ -26,7 +26,6 @@ class CommandFlagInfo {
 public:
 	const std::wstring getFirstCode() const { return _codes[0]; }
 	const bool hasCode(const std::wstring code) const { return _codes.contains(code); }
-	const bool requiresValue() const {}
 	static const easy_list::list<CommandFlagInfo>* getList();
 	static const easy_list::list<std::pair<CommandFlagInfo, CommandFlagInfo>>* getContradictoriesList();
 	bool operator==(const CommandFlagInfo& other) const;

--- a/Command.h
+++ b/Command.h
@@ -26,24 +26,29 @@ class CommandFlagInfo {
 public:
 	const std::wstring getFirstCode() const { return _codes[0]; }
 	const bool hasCode(const std::wstring code) const { return _codes.contains(code); }
+	const CommandType getCommandType() const { return _commandType; }
 	static const easy_list::list<CommandFlagInfo>* getList();
 	static const easy_list::list<std::pair<CommandFlagInfo, CommandFlagInfo>>* getContradictoriesList();
 	bool operator==(const CommandFlagInfo& other) const;
 private:
+	const CommandType _commandType;
 	const easy_list::list<std::wstring> _codes;
 	const bool _requiresValue;
 	const bool _allowsValue;
-	CommandFlagInfo(easy_list::list<std::wstring> codes) :
+	CommandFlagInfo(CommandType commandType, easy_list::list<std::wstring> codes) :
+		_commandType(commandType),
 		_codes(codes),
 		_requiresValue(false),
 		_allowsValue(false)
 	{}
-	CommandFlagInfo(easy_list::list<std::wstring> codes, bool takesValue) :
+	CommandFlagInfo(CommandType commandType, easy_list::list<std::wstring> codes, bool takesValue) :
+		_commandType(commandType),
 		_codes(codes),
 		_requiresValue(takesValue),
 		_allowsValue(takesValue)
 	{}
-	CommandFlagInfo(easy_list::list<std::wstring> codes, bool requiresValue, bool allowsValue) :
+	CommandFlagInfo(CommandType commandType, easy_list::list<std::wstring> codes, bool requiresValue, bool allowsValue) :
+		_commandType(commandType),
 		_codes(codes),
 		_requiresValue(requiresValue),
 		_allowsValue(allowsValue)
@@ -66,7 +71,7 @@ public:
 		_hasValue(true),
 		_value(value)
 	{}
-	bool isValid() const;
+	bool isValid(CommandType commandType) const;
 	bool contradicts(CommandFlag other) const;
 	bool operator==(const CommandFlag& rhs) const;
 	std::wstring toString() const {
@@ -94,7 +99,8 @@ public:
 	{
 		_data = static_cast<easy_list::list<CommandFlag>>(data);
 	}
-	bool isValid() const;
+	const easy_list::list<CommandFlag> getList() const { return _data; }
+	bool isValid(CommandType commandType) const;
 	CommandFlagCollection& add(const CommandFlag& rhs);
 	CommandFlagCollection& add(const CommandFlagCollection& rhs);
 	bool sharesAny(const CommandFlagCollection& other) const;
@@ -111,6 +117,7 @@ public:
 	const CommandType getType() const { return _type; }
 	const std::wstring getFirstCode() const { return _codes[0]; }
 	const bool hasCode(const std::wstring code) const { return _codes.contains(code); }
+	const int countValidFlags(CommandFlagCollection flags);
 	const CommandFunc getFunc() const { return _func; }
 	DEFINE_CMD_FUNC(callFunc) const { return _func(args, flags); }
 	static const easy_list::list<CommandInfo>* getList();

--- a/Command.h
+++ b/Command.h
@@ -2,10 +2,11 @@
 #include <string>
 #include <easy_list.h>
 #include <fstream>
+#include <template_helpers.h>
 #include "HandlerReturns.h"
 
-#define DECLARE_CMD_FUNC(funcName) CommandHandlerReturns funcName(easy_list::list<std::wstring> args = easy_list::list<std::wstring>())
-#define DEFINE_CMD_FUNC(funcName) CommandHandlerReturns funcName(easy_list::list<std::wstring> args)
+#define DECLARE_CMD_FUNC(funcName) CommandHandlerReturns funcName(easy_list::list<std::wstring> args, CommandFlags flags)
+#define DEFINE_CMD_FUNC(funcName) CommandHandlerReturns funcName(easy_list::list<std::wstring> args, CommandFlags flags)
 
 enum class CommandType {
 	CANCEL,
@@ -18,15 +19,80 @@ enum class CommandType {
 	PLAY
 };
 
-using CommandFunc = CommandHandlerReturns(*)(easy_list::list<std::wstring> args);
+enum class CommandFlags : char {
+	NONE = 0,
+	//FIRST = 1 << 0,
+	//SECOND = 1 << 1,
+	//THIRD = 1 << 2,
+	//FOURTH = 1 << 3,
+};
+
+inline CommandFlags operator&(CommandFlags lhs, CommandFlags rhs)
+{
+	return (CommandFlags)((char)lhs & (char)rhs);
+}
+
+inline CommandFlags operator|(CommandFlags lhs, CommandFlags rhs)
+{
+	return (CommandFlags)((char)lhs | (char)rhs);
+}
+
+inline CommandFlags operator~(CommandFlags flags)
+{
+	return (CommandFlags)~(char)flags;
+}
+
+inline CommandFlags operator&=(CommandFlags lhs, CommandFlags rhs)
+{
+	return lhs = (CommandFlags)((char)lhs & (char)rhs);
+}
+
+inline CommandFlags operator|=(CommandFlags lhs, CommandFlags rhs)
+{
+	return lhs = (CommandFlags)((char)lhs | (char)rhs);
+}
+
+template<typename ..._CommandFlags, std::enable_if_t<std::conjunction_v<std::is_same<_CommandFlags, CommandFlags>...>, bool> = true>
+inline bool sharesAny(CommandFlags flags, CommandFlags first, _CommandFlags... rest)
+{
+	if ((flags & first) != CommandFlags::NONE) return true;
+	for each (CommandFlags other in std::tuple<CommandFlags>(rest...))
+	{
+		if ((flags & other) != CommandFlags::NONE)
+			return true;
+	}
+	return false;
+}
+
+class CommandFlagInfo {
+public:
+	const CommandFlags getFlag() const { return _flag; }
+	const std::wstring getFirstCode() const { return _codes[0]; }
+	const bool hasCode(const std::wstring code) const { return _codes.contains(code); }
+	static const easy_list::list<CommandFlagInfo>* getList();
+	static const std::wstring getFirstCode(const CommandFlags flag);
+	bool operator==(const CommandFlagInfo& other)
+	{
+		return _flag == other._flag;
+	}
+private:
+	const CommandFlags _flag;
+	const easy_list::list<std::wstring> _codes;
+	CommandFlagInfo(const CommandFlags flag, easy_list::list<std::wstring> codes) :
+		_flag(flag),
+		_codes(codes)
+	{}
+};
+
+using CommandFunc = CommandHandlerReturns(*)(easy_list::list<std::wstring> args, CommandFlags flags);
 
 class CommandInfo {
 public:
 	const CommandType getType() const { return _type; }
-	const std::wstring getCode() const { return _codes[0]; }
+	const std::wstring getFirstCode() const { return _codes[0]; }
 	const bool hasCode(const std::wstring code) const { return _codes.contains(code); }
 	const CommandFunc getFunc() const { return _func; }
-	CommandHandlerReturns callFunc(easy_list::list<std::wstring> args) const { return _func(args); }
+	DEFINE_CMD_FUNC(callFunc) const { return _func(args, flags); }
 	static const easy_list::list<CommandInfo>* getList();
 	static const std::wstring getFirstCode(const CommandType ct);
 	bool operator==(const CommandInfo& other)
@@ -52,8 +118,10 @@ public:
 	CommandHandlerReturns doCommandFunc() const;
 	const CommandInfo getCommandInfo() const;
 	const easy_list::list<std::wstring> getArgs() const;
+	const CommandFlags getFlags() const;
 private:
 	CommandInfo _commandInfo;
 	easy_list::list<std::wstring> _args;
-	Command(easy_list::list<std::wstring> args, CommandInfo commandInfo);
+	CommandFlags _flags;
+	Command(easy_list::list<std::wstring> args, CommandFlags flags, CommandInfo commandInfo);
 };

--- a/Handlers.cpp
+++ b/Handlers.cpp
@@ -85,6 +85,10 @@ CommandHandlerReturns CommandHandler::call(std::wstring input)
 	if (possibleCommands.empty())
 		return CommandHandlerReturns::INVALID_STATE;
 
+	std::wcout << L"Command type:\t" << possibleCommands[0].getCommandInfo().getFirstCode() << L"\n"
+		<< L"Command arguments:" << possibleCommands[0].getArgs().transform<std::wstring>([](std::wstring arg) -> std::wstring { return L"\t" + arg; }) << L"\n"
+		<< L"Command flags:\t" << possibleCommands[0].getFlags().toString() << L"\n";
+
 	return possibleCommands[0].doCommandFunc();
 }
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command-line console app for practicing user-made quiz questions.
 
 ## Commands
 
-Commands all follow the syntax, <code>\\<command> [arg1] [arg2] ...</code>, where <code>[arg1], [arg2], ...</code> are any arguments, and <code><command></code> is the command code. The backslash <code>\\</code> is to distinguish commands from other inputs, such as writing new questions or answering questions. If the user provides more arguments than the command handler knows what to do with, the handler discards the excess arguments and carries on.
+Commands all follow the syntax, <code>\\\<command> [arg1] [arg2] ...</code>, where <code>[arg1], [arg2], ...</code> are any arguments, and <code><command></code> is the command code. The backslash <code>\\</code> is to distinguish commands from other inputs, such as writing new questions or answering questions. If the user provides more arguments than the command handler knows what to do with, the handler discards the excess arguments and carries on.
 
 See [Play](#Play) for more on the <code>play</code> command, and see [Write](#Write) for more on the <code>write</code> command.
 
@@ -12,8 +12,8 @@ At any time, the user may call the quit command with <code>\\quit</code> or <cod
 
 When in play, the following commands may be valid:
 
-	\\concede
-	\\boost
+	\concede
+	\boost
 
 The concede command ends play early, skipping any remaining questions. The boost command should be used just after giving a wrong answer, and re-marks your answer as correct - you should use this if you think you have been marked down unfairly, for example, if you made a minor spelling mistake or typo.
 
@@ -25,7 +25,7 @@ When writing new questions, the <code>\\cancel</code> command may be valid. This
 
 This is the syntax for the play command:
 
-	\\play [tag1] [tag2] ...
+	\play [tag1] [tag2] ...
 
 If at least one tag is specified, the app plays all and only questions with at least one of the specified tags. If no tags are specified, all questions are played. Questions are always randomly shuffled before play.
 
@@ -53,7 +53,7 @@ What children are there of <code>Question</code>?
 
 The syntax for the write command is as follows:
 
-	\\write <type>
+	\write <type>
 
 where <code><type></code> is the name of one of the implemented question types. (No commands are ever case-sensitive.)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A command-line console app for practicing user-made quiz questions.
 
 ## Commands
 
-Commands all follow the syntax, <code>\\\<command> [arg1] [arg2] ...</code>, where <code>[arg1], [arg2], ...</code> are any arguments, and <code><command></code> is the command code. The backslash <code>\\</code> is to distinguish commands from other inputs, such as writing new questions or answering questions. If the user provides more arguments than the command handler knows what to do with, the handler discards the excess arguments and carries on.
+Commands all follow the syntax, <code>\\\<command\> [arg1] [arg2] ...</code>, where <code>[arg1], [arg2], ...</code> are any arguments, and <code>\<command\></code> is the command code. The backslash <code>\\</code> is to distinguish commands from other inputs, such as writing new questions or answering questions. If the user provides more arguments than the command handler knows what to do with, the handler discards the excess arguments and carries on.
 
 See [Play](#Play) for more on the <code>play</code> command, and see [Write](#Write) for more on the <code>write</code> command.
 
@@ -55,7 +55,7 @@ The syntax for the write command is as follows:
 
 	\write <type>
 
-where <code><type></code> is the name of one of the implemented question types. (No commands are ever case-sensitive.)
+where <code>\<type\></code> is the name of one of the implemented question types. (No commands are ever case-sensitive.)
 
 The user is then led step-by-step through the process of writing new questions of the respective type. If they want to cancel writing a question halfway through, they may use the <code>cancel</code> command at any time. The new questions are written to file, and loaded ready for play, once the user has finished adding new questions.
 

--- a/util.cpp
+++ b/util.cpp
@@ -114,3 +114,45 @@ easy_list::list<std::wstring> splitByWord(std::wstring wstr)
 
 	return result;
 }
+
+easy_list::list<std::wstring> splitByWordOrQuotes(std::wstring wstr)
+{
+	easy_list::list<std::wstring> result = easy_list::list<std::wstring>();
+
+	std::wstring currentStr = L"";
+	bool waitingForEndQuote = false;
+	for (unsigned int i = 0; i < wstr.length(); i++)
+	{
+		if (wstr[i] == L'\"')
+		{
+			if (waitingForEndQuote)
+			{
+				result.push_back(currentStr);
+				currentStr = L"";
+				waitingForEndQuote = false;
+			}
+			else
+				waitingForEndQuote = true;
+			continue;
+		}
+
+		else if (wstr[i] == L' ')
+		{
+			if (!currentStr.empty())
+			{
+				result.push_back(currentStr);
+				currentStr = L"";
+			}
+			continue;
+		}
+
+		currentStr.push_back(wstr[i]);
+	}
+	if (!currentStr.empty())
+	{
+		result.push_back(currentStr);
+		currentStr = L"";
+	}
+
+	return result;
+}

--- a/util.h
+++ b/util.h
@@ -28,3 +28,4 @@ std::wstring toLower(std::wstring wstr);
 std::wstring indent(std::wstring wstr, int numTabs);
 const YesNo getYesNo(std::wstring wstr);
 easy_list::list<std::wstring> splitByWord(std::wstring wstr);
+easy_list::list<std::wstring> splitByWordOrQuotes(std::wstring wstr);


### PR DESCRIPTION
Implements command flags. In the process, I've gotten clearer about the standard way of doing cli commands - command code, then arguments, in order, then flags, in any order. Flags may carry values. Ordinarily, spaces split parts of the line, but not if to the right of an unclosed double quote ". I have decided to precede flags with a single dash -, and values are preceded with =, as in flag=value.